### PR TITLE
Reasonable default value for kick_rank

### DIFF
--- a/solve/dmrg_eigb.m
+++ b/solve/dmrg_eigb.m
@@ -38,7 +38,7 @@ rmax=2500;
 nswp=4;
 msize=1000;
 max_l_steps=200;
-kick_rank=0;
+kick_rank=5;
 verb=true;
 for i=1:2:length(varargin)-1
     switch lower(varargin{i})


### PR DESCRIPTION
I'm not sure, but it seems like a typo (comments says that kick_rank should be equal to 5). In my experiments kick_rank = 5 works better.
