### PR TITLE
Bug fix: tt_matrix should correctly take row vectors as input.

### DIFF
--- a/@tt_matrix/tt_matrix.m
+++ b/@tt_matrix/tt_matrix.m
@@ -43,8 +43,8 @@ if (isa(varargin{1}, 'tt_tensor'))
     tt=varargin{1};
     d=tt.d;
     if (nargin==3)&&(isa(varargin{2},'double'))&&(isa(varargin{3},'double'))
-        n=varargin{2};
-        m=varargin{3};
+        n=varargin{2}(:);
+        m=varargin{3}(:);
         if ( numel(n) == 1 )
             n=n*ones(d,1);
         end


### PR DESCRIPTION
Without this fix, if you try to use tt_matrix with rows vector mode size it works, but will eventually crash.

Example:

> > row = [2, 3, 2];
> > tt = tt_zeros(row .\* row);
> > tt_m = tt_matrix(tt, row, row); % No error here
> > tt_m \* tt_m;
> > Error using  .\* 
> > Matrix dimensions must agree.

Error in tt_matrix/mtimes (line 101)
    tt.ps = cumsum([1; tt.r(1:d)._n._m.*tt.r(2:d+1)]);
