### PR TITLE
vertcat\horzcat funcs overloaded for tt_matrix and tt_tensors. 

### DIFF
--- a/@tt_matrix/horzcat.m
+++ b/@tt_matrix/horzcat.m
@@ -1,0 +1,9 @@
+function y=horzcat(varargin)
+%By Alexey Boyko, Skolkovo Institute of Science and Technology,
+%a.boyko@skoltech.ru
+%alexey.boyko@skolkovotech.ru
+%Moscow, Russia, 2015
+%contribution to TT-Toolbox by Oseledets et.al
+
+y=tt_blockwise(varargin);
+end

--- a/@tt_matrix/vertcat.m
+++ b/@tt_matrix/vertcat.m
@@ -1,0 +1,9 @@
+function y=vertcat(varargin)
+%By Alexey Boyko, Skolkovo Institute of Science and Technology,
+%a.boyko@skoltech.ru
+%alexey.boyko@skolkovotech.ru
+%Moscow, Russia, 2015
+%contribution to TT-Toolbox by Oseledets et.al
+
+y=tt_blockwise(varargin.');
+end

--- a/@tt_tensor/vertcat2.m
+++ b/@tt_tensor/vertcat2.m
@@ -1,0 +1,98 @@
+function [c]=vertcat(varargin)
+%C=[A;B;...]
+%   C=VERTCAT(A,B,...) Computes "addition of columns" of TT-tensors.
+%   The result has r(1) = sum(varargin{i}.r(1)). The last ranks should be
+%   equal for all arguments
+%
+%
+% TT-Toolbox 2.2, 2009-2012
+%
+%This is TT Toolbox, written by Ivan Oseledets et al.
+%Institute of Numerical Mathematics, Moscow, Russia
+%webpage: http://spring.inm.ras.ru/osel
+%
+%For all questions, bugs and suggestions please mail
+%ivan.oseledets@gmail.com
+%---------------------------
+
+
+c = varargin{1};
+d = c.d;
+n = c.n;
+ra = c.r;
+ps = c.ps;
+r = ra;
+for i=2:nargin
+    b = varargin{i};
+    rb = b.r;
+    if (r(d+1)~=rb(d+1))
+        error('Inconsistent r(d+1) found, please check the arguments');
+    end
+    r(1:d) = r(1:d)+rb(1:d);
+end;
+
+cr = cell(d,1);
+for i=1:d
+    cr{i} = zeros(r(i), n(i), r(i+1));
+    cr{i}(1:ra(i), :, 1:ra(i+1)) = reshape(c.core(ps(i):ps(i+1)-1), ra(i), n(i), ra(i+1));
+end;
+
+curr = ra;
+for j=2:nargin
+    b = varargin{j};
+    rb = b.r;
+    ps = b.ps;
+    for i=1:d-1
+        cr{i}(curr(i)+1:curr(i)+rb(i), :, curr(i+1)+1:curr(i+1)+rb(i+1)) = reshape(b.core(ps(i):ps(i+1)-1), rb(i), n(i), rb(i+1));
+    end;
+    cr{d}(curr(d)+1:curr(d)+rb(d), :, 1:r(d+1)) = reshape(b.core(ps(d):ps(d+1)-1), rb(d), n(d), rb(d+1));    
+    curr = curr+rb;
+end;
+
+c = cell2core(c, cr);
+
+
+% if (isempty(b) )
+%   c=a;
+%   return
+% elseif (isempty(a) )
+%   c=b;
+%   return
+% end
+% c=tt_tensor;
+% d=a.d;
+% ra=a.r;
+% n=a.n;
+% psa=a.ps;
+% cra=a.core;
+% rb=b.r;
+% crb=b.core;
+% psb=b.ps;
+% rc=ra+rb; 
+% if ( ra(d+1) == rb(d+1) )
+% rc(d+1)=ra(d+1); %The only modification
+% else
+%   error('Incorrect sizes in [A;B], please check');    
+% end
+% psc=cumsum([1;n.*rc(1:d).*rc(2:d+1)]);
+% crc=zeros(1,psc(d+1)-1);
+% 
+% %It seems: Ak
+% %          Bk --- the first core 
+% %all others are blocks
+% 
+% for i=1:d
+%   cr1=cra(psa(i):psa(i+1)-1);
+%   cr2=crb(psb(i):psb(i+1)-1);
+%   cr1=reshape(cr1,[ra(i),n(i),ra(i+1)]);
+%   cr2=reshape(cr2,[rb(i),n(i),rb(i+1)]);
+%   cr3=zeros(rc(i),n(i),rc(i+1));
+%   cr3(1:ra(i),:,1:ra(i+1))=cr1;
+%   cr3(rc(i)-rb(i)+1:rc(i),:,rc(i+1)-rb(i+1)+1:rc(i+1))=cr2;
+%   crc(psc(i):psc(i+1)-1)=cr3(:);
+% end
+% c.ps=psc;
+% c.d=d;
+% c.n=n;
+% c.r=rc;
+% c.core=crc;

--- a/tt_blockwise.m
+++ b/tt_blockwise.m
@@ -1,0 +1,36 @@
+function y = tt_blockwise(arr)
+%By Alexey Boyko, Skolkovo Institute of Science and Technology,
+%a.boyko@skoltech.ru
+%alexey.boyko@skolkovotech.ru
+%Moscow, Russia, 2015
+%contribution to TT-Toolbox by Oseledets et.al
+%
+%INPUTS
+% arr {2d cell array} of <tt_matrix>  variables
+%OUTPUTS
+% y <tt_matrix> 
+%
+%this function assembles a block matrix in tt-format from a given 2d cell array
+%of blocks in tt-format
+
+    [n,m]=size(arr); 
+
+    block=zeros(n,m); block(1,1)=1;
+    %since current version of TT-Toolbox doesn't support 
+    %init like M=0; M=M+<tt_matrix>, one should construct 
+    %a valid tt_matrix of consistent dimensions as an initial variable.
+    
+    
+    y=tkron(arr{1,1},tt_matrix(block));
+
+    for i=1:n
+        for j=1:m
+%             full(a{i,j})
+            if (i~=1)||(j~=1)
+                block=zeros(n,m); block(i,j)=1;
+                y=y+tkron(arr{i,j},tt_matrix(block));
+            end
+        end
+    end
+return 
+end


### PR DESCRIPTION
Now works just like in full format.
Let's call it TT-Toolbox 2.3