### PR TITLE
Add tt_broadcast(A, n_extra). Simillar to Numpy function 'numpy.broad…

### DIFF
--- a/core/tt_broadcast.m
+++ b/core/tt_broadcast.m
@@ -1,0 +1,28 @@
+function [B]=tt_broadcast(A, n_extra)
+
+% Simillar to Numpy function 'numpy.broadcast_to'.
+% this function broadcast TT tensor A at extra dimensions with specified
+% mode sizes.
+
+% return a new TT tensor with B.n=[A.n; n_extra], and B.d=A.d +length(n_extra), 
+% containing prod(n_extra) copies of A. 
+
+% n_extra: vector of integers, gives the mode sizes of extra dimensions.
+% length(n_extra): number of extra dimensions.
+
+sn=size(n_extra);
+if sn(2)>sn(1)
+    n_extra=n_extra';
+end
+extra_dim= length(n_extra);
+
+B=tt_ones(n_extra,extra_dim);
+ 
+B.ps=[  A.ps(1:end) ; A.ps(end)+cumsum(n_extra)];
+B.core= [A.core; B.core];
+
+B.n = [A.n; B.n];
+B.r = [A.r; B.r(2:end)];
+B.d = A.d+B.d; 
+end
+


### PR DESCRIPTION
Add tt_broadcast(A, n_extra). Simillar to Numpy function 'numpy.broadcast_to', this function broadcast TT tensor A at extra dimensions with specified mode sizes. The function is useful at binary operations of two TT with different shapes. 
For example A.*B with A shape (2,3) and B shape (2,3,4,5), we could firstly do A=tt_broadcast(A, [4,5]) to broadcast A to the same shape of B and do A.*B.