### PR TITLE
solved possible bug in Rs rescaling

### DIFF
--- a/solve/amen_solve2.m
+++ b/solve/amen_solve2.m
@@ -397,7 +397,7 @@ for swp=1:nswp
             rr=qr(res2.', 0);
             Rs{i} = triu(rr(1:min(size(rr)), :)).';
             curnorm = norm(Rs{i}, 'fro');
-            if (Rs{i}>0)
+            if (curnorm>0)
                 Rs{i} = Rs{i}/curnorm;
             end;
         end;


### PR DESCRIPTION
Dears, 

is this a bug? Seems to me. 

The if statement will never be true. 

RS{i} is the upper triangular of something, and it will necessarily contain few zeros. 

best,
NC

